### PR TITLE
Fix creating unnecessary interval

### DIFF
--- a/js/better-simple-slideshow.js
+++ b/js/better-simple-slideshow.js
@@ -96,12 +96,15 @@ var makeBSS = function (el, options) {
                 
                 if (pauseOnHover) {
                     el.addEventListener('mouseover', function () {
-                        interval = clearInterval(interval);
+                        clearInterval(interval);
+                        interval = null;
                     }, false);
                     el.addEventListener('mouseout', function () {
-                        interval = window.setInterval(function () {
-                            that.showCurrent(1); // increment & show
-                        }, speed);
+                        if(!interval) {
+                            interval = window.setInterval(function () {
+                                that.showCurrent(1); // increment & show
+                            }, speed);
+                        }
                     }, false);
                 } // end pauseonhover
                 


### PR DESCRIPTION
closes #6 
I found that sometimes interval is created multiple times. I could reproduce it opening page and keeping cursor still on image. This causes gallery to advance to next slides even if my cursor on. Moving mouse away creates next interval, and reference to the previous is lost.