### PR TITLE
Fix for gap under slideshow when trying to add a border.

### DIFF
--- a/css/simple-slideshow-styles.css
+++ b/css/simple-slideshow-styles.css
@@ -1,6 +1,10 @@
 .bss-slides{
   position: relative;
-  display: block;    
+  display: block; 
+  line-height: 0;/*removes the gap if you put a border on the slideshow div*/   
+}
+figcaption {
+  line-height: 1.5; /* restores line-height to the child element*/
 }
 .bss-slides:focus{
  outline: 0;

--- a/css/simple-slideshow-styles.css~
+++ b/css/simple-slideshow-styles.css~
@@ -1,10 +1,13 @@
 .bss-slides{
   position: relative;
   display: block; 
-  line-height: 0;/*removes the gap if you put a border on the slideshow div*/   
+   line-height: 0;/*removes the gap if you put a border on the slideshow div*/   
 }
 figcaption {
-  line-height: 1.5; /* restores line-height to the child element*/
+	line-height: 1.5; /* restores line-height to the child element*/
+	}
+.bss-slides:focus{
+ outline: 0;
 }
 .bss-slides figure{
   position: absolute;
@@ -16,7 +19,9 @@ figcaption {
 }
 .bss-slides figure img{
   opacity: 0;
+  -webkit-transition: opacity 1.2s;
   transition: opacity 1.2s;
+  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
 }
 .bss-slides .bss-show{
@@ -24,6 +29,7 @@ figcaption {
 }
 .bss-slides .bss-show img{
   opacity: 1;
+  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   position: relative; 
 }
@@ -40,6 +46,7 @@ figcaption {
   background: rgba(0,0,0, .25);
   border-radius: 2px;
   opacity: 0;
+  -webkit-transition: opacity 1.2s;
   transition: opacity 1.2s;
 }
 .bss-slides .bss-show figcaption{
@@ -59,6 +66,9 @@ figcaption {
   font-size: 2em;
   margin-top: -1.2em;
   opacity: .3;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
   user-select: none;
 }
 .bss-next:hover, .bss-prev:hover{
@@ -82,6 +92,7 @@ figcaption {
   width: 32px;
   height: 32px;    
   background: rgba(0,0,0,.4) url(../img/arrows-alt_ffffff_64.png); 
+  -webkit-background-size: contain; 
   background-size: contain;
   position: absolute;
   top: 5px;
@@ -94,6 +105,7 @@ figcaption {
 }
 :-webkit-full-screen .bss-fullscreen{
     background: rgba(0,0,0,.4) url(../img/compress_ffffff_64.png);
+    -webkit-background-size: contain;
     background-size: contain;
 }
 :-moz-full-screen .bss-fullscreen{
@@ -106,9 +118,24 @@ figcaption {
 }
 :full-screen .bss-fullscreen{
     background: rgba(0,0,0,.4) url(../img/compress_ffffff_64.png);
+    -webkit-background-size: contain;
+    background-size: contain;
+}
+:-webkit-full-screen .bss-fullscreen{
+    background: rgba(0,0,0,.4) url(../img/compress_ffffff_64.png);
+    -webkit-background-size: contain;
+    background-size: contain;
+}
+:-moz-full-screen .bss-fullscreen{
+    background: rgba(0,0,0,.4) url(../img/compress_ffffff_64.png);
+    background-size: contain;
+}
+:-ms-fullscreen .bss-fullscreen{
+    background: rgba(0,0,0,.4) url(../img/compress_ffffff_64.png);
     background-size: contain;
 }
 :fullscreen .bss-fullscreen{
     background: rgba(0,0,0,.4) url(../img/compress_ffffff_64.png);
+    -webkit-background-size: contain;
     background-size: contain;
 }

--- a/css/styles.css~
+++ b/css/styles.css~
@@ -6,6 +6,9 @@
 figcaption {
   line-height: 1.5; /* restores line-height to the child element*/
 }
+.bss-slides:focus{
+ outline: 0;
+}
 .bss-slides figure{
   position: absolute;
   top: 0;


### PR DESCRIPTION
Added line-height 0 to .bss-slides in stylesheets. Adjusted figcaption height to compensate.

Whenever I try to put a border on the slideshow, there is a gap at the bottom. I tried to fix it by making all the slides the same size, but that didn't work. I'm using the Skeleton framework https://github.com/dhg/Skeleton, but the effect is not coming from conflicting styles in it, because when I remove it, the problem is still there.

![pottery](https://cloud.githubusercontent.com/assets/12161459/23336975/65809796-fbad-11e6-814b-9db43e5b66cc.png)
![school](https://cloud.githubusercontent.com/assets/12161459/23336978/6c772600-fbad-11e6-806a-2353a64d1018.png)
![latestversion2](https://cloud.githubusercontent.com/assets/12161459/23336980/7b328cac-fbad-11e6-8b0e-cf794e33384c.png)

Example
http://codepen.io/suedinym/pen/pevQYR

Fork of your BSS Demo with border
https://codepen.io/suedinym/pen/YZPdBw

It's a little difficult to see on your demo, but becomes more obvious as you decrease the width of the browser.

I've been using an older version of the slideshow, but it also happens with the one I forked on 25 Feb 2017.

I tried a lot of things to get rid of the gap (which generally came down to not using a border) but finally came across this stack overflow post, and suggestion number 3 worked. [Mystery White space beneath image](http://stackoverflow.com/questions/31444891/mystery-white-space-underneath-image-tag/31445364#31445364)

So, in my fork, I've added line-height: 0; to .bss-slides and adjusted the figcaption height to compensate.

The fix, on my example
http://codepen.io/suedinym/pen/ryaoQQ

The fix on a fork of your demo
https://codepen.io/suedinym/pen/xqbmMo


